### PR TITLE
feat: lazy load PDF report

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -6,26 +6,24 @@ module.exports = {
     configure: (webpackConfig) => {
       // гарантируем, что объекты существуют
       webpackConfig.resolve = webpackConfig.resolve || {};
-      webpackConfig.resolve.alias = {
-        ...(webpackConfig.resolve.alias || {}),
-        // ВАЖНО: без .js — правильный экспорт
-        "react/jsx-runtime": require.resolve("react/jsx-runtime"),
-      };
-
       // Фолбэки для пакетов, которые ожидают ноды
       webpackConfig.resolve.fallback = {
         ...(webpackConfig.resolve.fallback || {}),
         process: require.resolve("process/browser"),
-        util: require.resolve("util/"),
-        buffer: require.resolve("buffer/"),
+        util: require.resolve("util"),
+        buffer: require.resolve("buffer"),
+        stream: require.resolve("stream-browserify"),
+        path: require.resolve("path-browserify"),
+        crypto: require.resolve("crypto-browserify"),
+        events: require.resolve("events"),
       };
 
       // Полифил глобалов (некоторые пакеты ждут process и Buffer)
       webpackConfig.plugins = webpackConfig.plugins || [];
       webpackConfig.plugins.push(
         new webpack.ProvidePlugin({
-          process: "process/browser",
           Buffer: ["buffer", "Buffer"],
+          process: ["process"],
         })
       );
 

--- a/src/AdsRaysInterface.jsx
+++ b/src/AdsRaysInterface.jsx
@@ -9,8 +9,9 @@
 import React, { useMemo, useState } from "react";
 import Papa from "papaparse";
 import { fetchAdInsights } from "./lib/metaApi";
-import PDFReport from "./components/PDFReport";
 import AgeBreakdownPanel from "./components/AgeBreakdownPanel"; // если файл лежит в src/
+
+const PDFReport = React.lazy(() => import("./components/PDFReport"));
 
 
 
@@ -262,6 +263,7 @@ export default function AdsRaysInterface() {
   const [expandedCampaigns, setExpandedCampaigns] = useState(new Set());
   const [campaignCreatives, setCampaignCreatives] = useState({}); // { [campaignId]: Array<creative> }
   const [loadingCreatives, setLoadingCreatives] = useState(new Set());
+  const [showPDF] = useState(false);
 
   // Загрузка кампаний (реальные данные)
   async function handleLoadCampaigns() {
@@ -1099,6 +1101,11 @@ const creativeObjectivesInSelection = useMemo(() => {
                   );
                 })()}
               </div>
+            )}
+            {showPDF && (
+              <React.Suspense fallback={<div>Загрузка PDF...</div>}>
+                <PDFReport formData={{}} campaignHistory={[]} />
+              </React.Suspense>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
- lazy-load PDF report component and wrap its usage with `React.Suspense`
- extend webpack fallbacks for stream, path, crypto and events through browserify packages
- remove `react/jsx-runtime` alias and expose Buffer and process globals via `ProvidePlugin`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b65d90f48327b76d266912e94bdd